### PR TITLE
A couple missing cases of ArrowExpressions: `() => x` and `a => b`.

### DIFF
--- a/src/Language/JavaScript/Parser/Grammar7.y
+++ b/src/Language/JavaScript/Parser/Grammar7.y
@@ -1115,11 +1115,20 @@ FunctionExpression : ArrowFunctionExpression     { $1 {- 'ArrowFunctionExpressio
                    | LambdaExpression            { $1 {- 'FunctionExpression1' -} }
                    | NamedFunctionExpression     { $1 {- 'FunctionExpression2' -} }
 
+
 ArrowFunctionExpression :: { AST.JSExpression }
-ArrowFunctionExpression : LParen FormalParameterList RParen Arrow Expression
+ArrowFunctionExpression : SingleFormalParamter Arrow Expression
+                           { AST.JSArrowExpression AST.JSNoAnnot $1 AST.JSNoAnnot AST.JSNoAnnot (Left $3) }
+                        | SingleFormalParamter Arrow FunctionBody
+                           { AST.JSArrowExpression AST.JSNoAnnot $1 AST.JSNoAnnot AST.JSNoAnnot (Right $3) }
+                        | LParen FormalParameterList RParen Arrow Expression
                            { AST.JSArrowExpression $1 $2 $3 $4 (Left $5) }
                         | LParen FormalParameterList RParen Arrow FunctionBody
                            { AST.JSArrowExpression $1 $2 $3 $4 (Right $5) }
+
+SingleFormalParamter :: { AST.JSCommaList AST.JSIdent }
+SingleFormalParamter : Identifier                            { AST.JSLOne (identName $1) }
+                     | LParen RParen                         { AST.JSLNil }
 
 NamedFunctionExpression :: { AST.JSExpression }
 NamedFunctionExpression : Function Identifier LParen RParen FunctionBody
@@ -1136,6 +1145,7 @@ LambdaExpression : Function LParen RParen FunctionBody
 IdentifierOpt :: { AST.JSIdent }
 IdentifierOpt : Identifier { identName $1     {- 'IdentifierOpt1' -} }
               |            { AST.JSIdentNone  {- 'IdentifierOpt2' -} }
+
 
 -- FormalParameterList :                                                      See clause 13
 --        Identifier

--- a/test/Test/Language/Javascript/ExpressionParser.hs
+++ b/test/Test/Language/Javascript/ExpressionParser.hs
@@ -126,8 +126,12 @@ testExpressionParser = describe "Parse expressions:" $ do
         testExpr "function(){}"     `shouldBe` "Right (JSAstExpression (JSFunctionExpression '' () (JSBlock []))))"
         testExpr "function(a){}"    `shouldBe` "Right (JSAstExpression (JSFunctionExpression '' (JSIdentifier 'a') (JSBlock []))))"
         testExpr "function(a,b){}"  `shouldBe` "Right (JSAstExpression (JSFunctionExpression '' (JSIdentifier 'a',JSIdentifier 'b') (JSBlock []))))"
-        testExpr "(a,b) => {}"  `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a',JSIdentifier 'b')) => JSBlock []))"
-        testExpr "(a,b) => a + b"  `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a',JSIdentifier 'b')) => JSExpressionBinary ('+',JSIdentifier 'a',JSIdentifier 'b')))"
+        testExpr "(a,b) => {}"      `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a',JSIdentifier 'b')) => JSBlock []))"
+        testExpr "(a) => {}"        `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a')) => JSBlock []))"
+        testExpr "a => {}"          `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a')) => JSBlock []))"
+        testExpr "() => {}"         `shouldBe` "Right (JSAstExpression (JSArrowExpression (()) => JSBlock []))"
+        testExpr "a => b"           `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a')) => JSIdentifier 'b'))"
+        testExpr "(a,b) => a + b"   `shouldBe` "Right (JSAstExpression (JSArrowExpression ((JSIdentifier 'a',JSIdentifier 'b')) => JSExpressionBinary ('+',JSIdentifier 'a',JSIdentifier 'b')))"
 
     it "member expression" $ do
         testExpr "x[y]"         `shouldBe` "Right (JSAstExpression (JSMemberSquare (JSIdentifier 'x',JSIdentifier 'y')))"


### PR DESCRIPTION
Notice, I think the cases for _ => a and (_) => b are missing too, or at least I couldn't figure how to implement these. Anyways, these are way down my priority list.

Btw, a small disclaimer. I made this PR and asking for you review because I never used happy grammars before, and to be honest, I am not a big fan of parser generator. 